### PR TITLE
fix: refund unused tokens on revert

### DIFF
--- a/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
@@ -264,6 +264,12 @@ abstract contract UniversalNFTCore is
         _safeMint(sender, tokenId);
         _setTokenURI(tokenId, uri);
         emit TokenTransferReverted(sender, tokenId, uri);
+
+        if (context.amount > 0 && context.asset != address(0)) {
+            if (!IZRC20(context.asset).transfer(sender, context.amount)) {
+                revert TransferFailed();
+            }
+        }
     }
 
     /**

--- a/contracts/token/contracts/zetachain/UniversalTokenCore.sol
+++ b/contracts/token/contracts/zetachain/UniversalTokenCore.sol
@@ -249,5 +249,11 @@ abstract contract UniversalTokenCore is
         );
         _mint(sender, amount);
         emit TokenTransferReverted(sender, amount);
+
+        if (context.amount > 0 && context.asset != address(0)) {
+            if (!IZRC20(context.asset).transfer(sender, context.amount)) {
+                revert TransferFailed();
+            }
+        }
     }
 }


### PR DESCRIPTION
When a transfer fails, refund unused ZRC-20 tokens to the original sender on ZetaChain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for cross-chain NFT and token transfers.
	- Implemented asset recovery mechanism for failed cross-chain transactions.
	- Improved transaction robustness by returning assets to the sender in case of transfer failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->