### PR TITLE
fix: check for zero address in setConnected

### DIFF
--- a/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
@@ -104,6 +104,7 @@ abstract contract UniversalNFTCore is
         address zrc20,
         address contractAddress
     ) external onlyOwner {
+        if (zrc20 == address(0)) revert InvalidAddress();
         connected[zrc20] = contractAddress;
         emit SetConnected(zrc20, contractAddress);
     }

--- a/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
@@ -105,6 +105,7 @@ abstract contract UniversalNFTCore is
         address contractAddress
     ) external onlyOwner {
         if (zrc20 == address(0)) revert InvalidAddress();
+        if (contractAddress == address(0)) revert InvalidAddress();
         connected[zrc20] = contractAddress;
         emit SetConnected(zrc20, contractAddress);
     }

--- a/contracts/token/contracts/zetachain/UniversalTokenCore.sol
+++ b/contracts/token/contracts/zetachain/UniversalTokenCore.sol
@@ -102,6 +102,7 @@ abstract contract UniversalTokenCore is
         address zrc20,
         address contractAddress
     ) external onlyOwner {
+        if (zrc20 == address(0)) revert InvalidAddress();
         connected[zrc20] = contractAddress;
         emit SetConnected(zrc20, contractAddress);
     }

--- a/contracts/token/contracts/zetachain/UniversalTokenCore.sol
+++ b/contracts/token/contracts/zetachain/UniversalTokenCore.sol
@@ -103,6 +103,7 @@ abstract contract UniversalTokenCore is
         address contractAddress
     ) external onlyOwner {
         if (zrc20 == address(0)) revert InvalidAddress();
+        if (contractAddress == address(0)) revert InvalidAddress();
         connected[zrc20] = contractAddress;
         emit SetConnected(zrc20, contractAddress);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced address validation in `setConnected` functions for both NFT and Token core contracts
  - Added checks to prevent setting zero addresses in contract connections

- **Security**
  - Improved error handling to prevent potential invalid address assignments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->