### PR TITLE
feat: refund tokens inside onRevert and onAbort

### DIFF
--- a/contracts/nft/contracts/evm/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/evm/UniversalNFTCore.sol
@@ -190,12 +190,12 @@ abstract contract UniversalNFTCore is
             context.revertMessage,
             (address, uint256, string, address)
         );
+        _safeMint(sender, tokenId);
+        _setTokenURI(tokenId, uri);
         if (context.amount > 0) {
             (bool success, ) = payable(sender).call{value: context.amount}("");
             if (!success) revert GasTokenRefundFailed();
         }
-        _safeMint(sender, tokenId);
-        _setTokenURI(tokenId, uri);
         emit TokenTransferReverted(sender, tokenId, uri);
     }
 

--- a/contracts/nft/contracts/evm/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/evm/UniversalNFTCore.sol
@@ -198,7 +198,13 @@ abstract contract UniversalNFTCore is
             (bool success, ) = payable(sender).call{value: context.amount}("");
             if (!success) revert GasTokenRefundFailed();
         }
-        emit TokenTransferReverted(sender, tokenId, uri);
+        emit TokenTransferReverted(
+            sender,
+            tokenId,
+            uri,
+            address(0), // gas token
+            context.amount
+        );
     }
 
     /**

--- a/contracts/nft/contracts/evm/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/evm/UniversalNFTCore.sol
@@ -37,6 +37,7 @@ abstract contract UniversalNFTCore is
     error Unauthorized();
     error InvalidGasLimit();
     error GasTokenTransferFailed();
+    error GasTokenRefundFailed();
 
     modifier onlyGateway() {
         if (msg.sender != address(gateway)) revert Unauthorized();
@@ -182,11 +183,17 @@ abstract contract UniversalNFTCore is
      * @dev Called by the Gateway if a call fails.
      * @param context The revert context containing metadata and revert message.
      */
-    function onRevert(RevertContext calldata context) external onlyGateway {
+    function onRevert(
+        RevertContext calldata context
+    ) external payable onlyGateway {
         (, uint256 tokenId, string memory uri, address sender) = abi.decode(
             context.revertMessage,
             (address, uint256, string, address)
         );
+        if (context.amount > 0) {
+            (bool success, ) = payable(sender).call{value: context.amount}("");
+            if (!success) revert GasTokenRefundFailed();
+        }
         _safeMint(sender, tokenId);
         _setTokenURI(tokenId, uri);
         emit TokenTransferReverted(sender, tokenId, uri);

--- a/contracts/nft/contracts/shared/UniversalNFTEvents.sol
+++ b/contracts/nft/contracts/shared/UniversalNFTEvents.sol
@@ -19,13 +19,17 @@ contract UniversalNFTEvents {
     event TokenTransferReverted(
         address indexed sender,
         uint256 indexed tokenId,
-        string uri
+        string uri,
+        address refundAsset,
+        uint256 refundAmount
     );
     event TokenTransferAborted(
         address indexed sender,
         uint256 indexed tokenId,
         string uri,
-        bool outgoing
+        bool outgoing,
+        address refundAsset,
+        uint256 refundAmount
     );
     event TokenTransferToDestination(
         address indexed destination,

--- a/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
@@ -265,7 +265,13 @@ abstract contract UniversalNFTCore is
         );
         _safeMint(sender, tokenId);
         _setTokenURI(tokenId, uri);
-        emit TokenTransferReverted(sender, tokenId, uri);
+        emit TokenTransferReverted(
+            sender,
+            tokenId,
+            uri,
+            context.asset,
+            context.amount
+        );
 
         if (context.amount > 0 && context.asset != address(0)) {
             if (!IZRC20(context.asset).transfer(sender, context.amount)) {
@@ -290,7 +296,14 @@ abstract contract UniversalNFTCore is
         );
         _safeMint(sender, tokenId);
         _setTokenURI(tokenId, uri);
-        emit TokenTransferAborted(sender, tokenId, uri, context.outgoing);
+        emit TokenTransferAborted(
+            sender,
+            tokenId,
+            uri,
+            context.outgoing,
+            context.asset,
+            context.amount
+        );
 
         if (context.amount > 0 && context.asset != address(0)) {
             if (!IZRC20(context.asset).transfer(sender, context.amount)) {

--- a/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
@@ -47,6 +47,7 @@ abstract contract UniversalNFTCore is
     error InvalidGasLimit();
     error ApproveFailed();
     error ZeroMsgValue();
+    error TokenRefundFailed();
 
     modifier onlyGateway() {
         if (msg.sender != address(gateway)) revert Unauthorized();
@@ -268,7 +269,7 @@ abstract contract UniversalNFTCore is
 
         if (context.amount > 0 && context.asset != address(0)) {
             if (!IZRC20(context.asset).transfer(sender, context.amount)) {
-                revert TransferFailed();
+                revert TokenRefundFailed();
             }
         }
     }
@@ -290,6 +291,12 @@ abstract contract UniversalNFTCore is
         _safeMint(sender, tokenId);
         _setTokenURI(tokenId, uri);
         emit TokenTransferAborted(sender, tokenId, uri, context.outgoing);
+
+        if (context.amount > 0 && context.asset != address(0)) {
+            if (!IZRC20(context.asset).transfer(sender, context.amount)) {
+                revert TokenRefundFailed();
+            }
+        }
     }
 
     /**

--- a/contracts/nft/package.json
+++ b/contracts/nft/package.json
@@ -31,7 +31,7 @@
     "@types/validator": "^13.12.2",
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.9",
-    "@zetachain/localnet": "6.0.0-rc6",
+    "@zetachain/localnet": "7.1.0-rc1",
     "@zetachain/toolkit": "13.0.0-rc8",
     "axios": "^1.3.6",
     "chai": "^4.2.0",

--- a/contracts/nft/scripts/localnet.sh
+++ b/contracts/nft/scripts/localnet.sh
@@ -62,7 +62,7 @@ npx hardhat localnet-check
 balance
 
 echo -e "\nTransferring NFT: Ethereum → BNB..."
-npx hardhat nft:transfer --network localhost --json --token-id "$NFT_ID" --contract "$CONTRACT_ETHEREUM" --destination "$ZRC20_BNB" --gas-amount 1
+npx hardhat nft:transfer --network localhost --json --token-id "$NFT_ID" --contract "$CONTRACT_ETHEREUM" --destination "$ZRC20_BNB" --gas-amount 0.000000000001
 
 npx hardhat localnet-check
 balance

--- a/contracts/nft/scripts/localnet.sh
+++ b/contracts/nft/scripts/localnet.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 set -o pipefail
 
-if [ "$1" = "start" ]; then npx hardhat localnet --exit-on-error & sleep 15; fi
+npx hardhat localnet --exit-on-error & sleep 15
 
 function balance() {
   local ZETACHAIN=$(cast call "$CONTRACT_ZETACHAIN" "balanceOf(address)(uint256)" "$SENDER")
@@ -67,10 +67,10 @@ npx hardhat nft:transfer --network localhost --json --token-id "$NFT_ID" --contr
 npx hardhat localnet-check
 balance
 
-echo -e "\nTransferring NFT: BNB → ZetaChain..."
-npx hardhat nft:transfer --network localhost --json --token-id "$NFT_ID" --contract "$CONTRACT_BNB"
+# echo -e "\nTransferring NFT: BNB → ZetaChain..."
+# npx hardhat nft:transfer --network localhost --json --token-id "$NFT_ID" --contract "$CONTRACT_BNB"
 
-npx hardhat localnet-check
-balance
+# npx hardhat localnet-check
+# balance
 
-if [ "$1" = "start" ]; then npx hardhat localnet-stop; fi
+# npx hardhat localnet-stop

--- a/contracts/nft/yarn.lock
+++ b/contracts/nft/yarn.lock
@@ -1918,6 +1918,18 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@metamask/eth-sig-util@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz#3ad61f6ea9ad73ba5b19db780d40d9aae5157088"
@@ -2564,7 +2576,7 @@
   dependencies:
     "@solana/codecs" "2.0.0-rc.1"
 
-"@solana/spl-token@^0.4.8":
+"@solana/spl-token@^0.4.12", "@solana/spl-token@^0.4.8":
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.4.13.tgz#8f65c3c2b315e1a00a91b8d0f60922c6eb71de62"
   integrity sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==
@@ -2983,18 +2995,19 @@
     typescript "5.5.4"
     zod "3.22.4"
 
-"@zetachain/localnet@6.0.0-rc6":
-  version "6.0.0-rc6"
-  resolved "https://registry.yarnpkg.com/@zetachain/localnet/-/localnet-6.0.0-rc6.tgz#4cb8ce2f3388019b2d90ef74de87e271ceb9cfc1"
-  integrity sha512-3AMK/ya9SJxBENeGs1+bZtVwXgDZCuTTOP2cfxHq90qPwrpMeZnHGhhm9PCcLhoodXDOx8z+S/4vkzWRj9ghdw==
+"@zetachain/localnet@7.1.0-rc1":
+  version "7.1.0-rc1"
+  resolved "https://registry.yarnpkg.com/@zetachain/localnet/-/localnet-7.1.0-rc1.tgz#583853c4d618685540bd84214820ecf9a30aecb1"
+  integrity sha512-CGuPhttRLj9pksWj5yGh7r2la3M43MTC66THIc3ptdDuspFt4MEFGxtOVgdmwR+QJi6mcc6nKk3rJhQF5XxByg==
   dependencies:
     "@coral-xyz/anchor" "^0.30.1"
     "@inquirer/prompts" "^5.5.0"
     "@mysten/sui" "^0.0.0-experimental-20250131013137"
+    "@solana/spl-token" "^0.4.12"
     "@solana/web3.js" "^1.95.4"
     "@uniswap/v2-core" "^1.0.1"
     "@uniswap/v2-periphery" "^1.1.0-beta.0"
-    "@zetachain/protocol-contracts" "11.0.0-rc5"
+    "@zetachain/protocol-contracts" "12.0.0-rc1"
     ansis "^3.3.2"
     bip39 "^3.1.0"
     bs58 "^6.0.0"
@@ -3002,7 +3015,11 @@
     ed25519-hd-key "^1.3.0"
     elliptic "6.5.7"
     ethers "^6.13.2"
+    fs-extra "^11.3.0"
     hardhat "^2.22.8"
+    js-sha256 "^0.11.0"
+    simple-git "^3.27.0"
+    sudo-prompt "^9.2.1"
     wait-on "^7.2.0"
 
 "@zetachain/networks@10.0.0", "@zetachain/networks@^10.0.0":
@@ -3011,16 +3028,6 @@
   integrity sha512-FPolaO19oVkSLSPDUA/Hu+8AhG3lDEslRDpLnMzbMbnNSC669Fkah0/TEf+6egrQbAifBRfFLzwWidAGs8oxtA==
   dependencies:
     dotenv "^16.1.4"
-
-"@zetachain/protocol-contracts@11.0.0-rc5":
-  version "11.0.0-rc5"
-  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-11.0.0-rc5.tgz#b55119e6cade29c4f266eb029d8879b968f87f63"
-  integrity sha512-+bjeTvSzuchWEIxrZ7IbOb8ERhZ+PtgmyOSSFcwhhyAOonYxNlM+1M/mSNAk5i3cdZyJTINzhk7H603/RQSeqA==
-  dependencies:
-    "@openzeppelin/contracts" "^5.0.2"
-    "@openzeppelin/contracts-upgradeable" "^5.0.2"
-    "@zetachain/networks" "^10.0.0"
-    ethers "5.6.8"
 
 "@zetachain/protocol-contracts@12.0.0-rc1":
   version "12.0.0-rc1"
@@ -5197,6 +5204,15 @@ fp-ts@^1.0.0:
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
   integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
 
+fs-extra@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
+  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
@@ -6061,6 +6077,11 @@ js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
+js-sha256@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.0.tgz#256a921d9292f7fe98905face82e367abaca9576"
+  integrity sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==
 
 js-sha3@0.5.7:
   version "0.5.7"
@@ -7327,6 +7348,15 @@ signal-exit@^4.1.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-git@^3.27.0:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.27.0.tgz#f4b09e807bda56a4a3968f635c0e4888d3decbd5"
+  integrity sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.5"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -7558,6 +7588,11 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+sudo-prompt@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-9.2.1.tgz#77efb84309c9ca489527a4e749f287e6bdd52afd"
+  integrity sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==
 
 superstruct@^0.15.4:
   version "0.15.5"

--- a/contracts/token/contracts/evm/UniversalTokenCore.sol
+++ b/contracts/token/contracts/evm/UniversalTokenCore.sol
@@ -190,7 +190,7 @@ abstract contract UniversalTokenCore is
             (bool success, ) = payable(sender).call{value: context.amount}("");
             if (!success) revert GasTokenRefundFailed();
         }
-        emit TokenTransferReverted(sender, amount);
+        emit TokenTransferReverted(sender, amount, address(0), context.amount);
     }
 
     receive() external payable {}

--- a/contracts/token/contracts/evm/UniversalTokenCore.sol
+++ b/contracts/token/contracts/evm/UniversalTokenCore.sol
@@ -178,12 +178,12 @@ abstract contract UniversalTokenCore is
      * @param context The revert context containing metadata and revert message.
      */
     function onRevert(RevertContext calldata context) external onlyGateway {
-        (uint256 amount, address receiver) = abi.decode(
+        (uint256 amount, address sender) = abi.decode(
             context.revertMessage,
             (uint256, address)
         );
-        _mint(receiver, amount);
-        emit TokenTransferReverted(receiver, amount);
+        _mint(sender, amount);
+        emit TokenTransferReverted(sender, amount);
     }
 
     receive() external payable {}

--- a/contracts/token/contracts/evm/UniversalTokenCore.sol
+++ b/contracts/token/contracts/evm/UniversalTokenCore.sol
@@ -183,11 +183,11 @@ abstract contract UniversalTokenCore is
             context.revertMessage,
             (uint256, address)
         );
+        _mint(sender, amount);
         if (context.amount > 0) {
             (bool success, ) = payable(sender).call{value: context.amount}("");
             if (!success) revert GasTokenRefundFailed();
         }
-        _mint(sender, amount);
         emit TokenTransferReverted(sender, amount);
     }
 

--- a/contracts/token/contracts/evm/UniversalTokenCore.sol
+++ b/contracts/token/contracts/evm/UniversalTokenCore.sol
@@ -190,7 +190,12 @@ abstract contract UniversalTokenCore is
             (bool success, ) = payable(sender).call{value: context.amount}("");
             if (!success) revert GasTokenRefundFailed();
         }
-        emit TokenTransferReverted(sender, amount, address(0), context.amount);
+        emit TokenTransferReverted(
+            sender,
+            amount,
+            address(0), // gas token
+            context.amount
+        );
     }
 
     receive() external payable {}

--- a/contracts/token/contracts/evm/UniversalTokenCore.sol
+++ b/contracts/token/contracts/evm/UniversalTokenCore.sol
@@ -36,6 +36,7 @@ abstract contract UniversalTokenCore is
     error Unauthorized();
     error InvalidGasLimit();
     error GasTokenTransferFailed();
+    error GasTokenRefundFailed();
 
     /**
      * @dev Ensures that the function can only be called by the Gateway contract.
@@ -182,6 +183,10 @@ abstract contract UniversalTokenCore is
             context.revertMessage,
             (uint256, address)
         );
+        if (context.amount > 0) {
+            (bool success, ) = payable(sender).call{value: context.amount}("");
+            if (!success) revert GasTokenRefundFailed();
+        }
         _mint(sender, amount);
         emit TokenTransferReverted(sender, amount);
     }

--- a/contracts/token/contracts/shared/UniversalTokenEvents.sol
+++ b/contracts/token/contracts/shared/UniversalTokenEvents.sol
@@ -11,8 +11,18 @@ contract UniversalTokenEvents {
         uint256 amount
     );
     event TokenTransferReceived(address indexed receiver, uint256 amount);
-    event TokenTransferReverted(address indexed sender, uint256 amount);
-    event TokenTransferAborted(address indexed sender, uint256 amount);
+    event TokenTransferReverted(
+        address indexed sender,
+        uint256 amount,
+        address refundAsset,
+        uint256 refundAmount
+    );
+    event TokenTransferAborted(
+        address indexed sender,
+        uint256 amount,
+        address refundAsset,
+        uint256 refundAmount
+    );
     event TokenTransferToDestination(
         address indexed destination,
         address indexed sender,

--- a/contracts/token/contracts/zetachain/UniversalTokenCore.sol
+++ b/contracts/token/contracts/zetachain/UniversalTokenCore.sol
@@ -251,7 +251,12 @@ abstract contract UniversalTokenCore is
             (address, uint256, address)
         );
         _mint(sender, amount);
-        emit TokenTransferReverted(sender, amount);
+        emit TokenTransferReverted(
+            sender,
+            amount,
+            context.asset,
+            context.amount
+        );
 
         if (context.amount > 0 && context.asset != address(0)) {
             if (!IZRC20(context.asset).transfer(sender, context.amount)) {
@@ -266,7 +271,12 @@ abstract contract UniversalTokenCore is
             (address, uint256, address)
         );
         _mint(sender, amount);
-        emit TokenTransferAborted(sender, amount);
+        emit TokenTransferAborted(
+            sender,
+            amount,
+            context.asset,
+            context.amount
+        );
 
         if (context.amount > 0 && context.asset != address(0)) {
             if (!IZRC20(context.asset).transfer(sender, context.amount)) {

--- a/contracts/token/contracts/zetachain/UniversalTokenCore.sol
+++ b/contracts/token/contracts/zetachain/UniversalTokenCore.sol
@@ -46,6 +46,7 @@ abstract contract UniversalTokenCore is
     error InvalidGasLimit();
     error ApproveFailed();
     error ZeroMsgValue();
+    error TokenRefundFailed();
 
     modifier onlyGateway() {
         if (msg.sender != address(gateway)) revert Unauthorized();
@@ -254,7 +255,7 @@ abstract contract UniversalTokenCore is
 
         if (context.amount > 0 && context.asset != address(0)) {
             if (!IZRC20(context.asset).transfer(sender, context.amount)) {
-                revert TransferFailed();
+                revert TokenRefundFailed();
             }
         }
     }
@@ -266,5 +267,11 @@ abstract contract UniversalTokenCore is
         );
         _mint(sender, amount);
         emit TokenTransferAborted(sender, amount);
+
+        if (context.amount > 0 && context.asset != address(0)) {
+            if (!IZRC20(context.asset).transfer(sender, context.amount)) {
+                revert TokenRefundFailed();
+            }
+        }
     }
 }

--- a/contracts/token/package.json
+++ b/contracts/token/package.json
@@ -28,7 +28,7 @@
     "@types/node": ">=12.0.0",
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.9",
-    "@zetachain/localnet": "6.0.0-rc6",
+    "@zetachain/localnet": "7.1.0-rc1",
     "@zetachain/toolkit": "13.0.0-rc8",
     "axios": "^1.3.6",
     "chai": "^4.2.0",

--- a/contracts/token/scripts/localnet.sh
+++ b/contracts/token/scripts/localnet.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 set -o pipefail
 
-if [ "$1" = "start" ]; then npx hardhat localnet --exit-on-error & sleep 15; fi
+npx hardhat localnet --exit-on-error & sleep 15
 
 function balance() {
   echo -e "\n🖼️  Balance"
@@ -73,4 +73,4 @@ npx hardhat token:transfer --network localhost --json --amount 10 --from "$CONTR
 npx hardhat localnet-check
 balance
 
-if [ "$1" = "start" ]; then npx hardhat localnet-stop; fi
+npx hardhat localnet-stop

--- a/contracts/token/yarn.lock
+++ b/contracts/token/yarn.lock
@@ -1918,6 +1918,18 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@metamask/eth-sig-util@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz#3ad61f6ea9ad73ba5b19db780d40d9aae5157088"
@@ -2541,7 +2553,7 @@
   dependencies:
     "@solana/codecs" "2.0.0-rc.1"
 
-"@solana/spl-token@^0.4.8":
+"@solana/spl-token@^0.4.12", "@solana/spl-token@^0.4.8":
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.4.13.tgz#8f65c3c2b315e1a00a91b8d0f60922c6eb71de62"
   integrity sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==
@@ -2955,18 +2967,19 @@
     typescript "5.5.4"
     zod "3.22.4"
 
-"@zetachain/localnet@6.0.0-rc6":
-  version "6.0.0-rc6"
-  resolved "https://registry.yarnpkg.com/@zetachain/localnet/-/localnet-6.0.0-rc6.tgz#4cb8ce2f3388019b2d90ef74de87e271ceb9cfc1"
-  integrity sha512-3AMK/ya9SJxBENeGs1+bZtVwXgDZCuTTOP2cfxHq90qPwrpMeZnHGhhm9PCcLhoodXDOx8z+S/4vkzWRj9ghdw==
+"@zetachain/localnet@7.1.0-rc1":
+  version "7.1.0-rc1"
+  resolved "https://registry.yarnpkg.com/@zetachain/localnet/-/localnet-7.1.0-rc1.tgz#583853c4d618685540bd84214820ecf9a30aecb1"
+  integrity sha512-CGuPhttRLj9pksWj5yGh7r2la3M43MTC66THIc3ptdDuspFt4MEFGxtOVgdmwR+QJi6mcc6nKk3rJhQF5XxByg==
   dependencies:
     "@coral-xyz/anchor" "^0.30.1"
     "@inquirer/prompts" "^5.5.0"
     "@mysten/sui" "^0.0.0-experimental-20250131013137"
+    "@solana/spl-token" "^0.4.12"
     "@solana/web3.js" "^1.95.4"
     "@uniswap/v2-core" "^1.0.1"
     "@uniswap/v2-periphery" "^1.1.0-beta.0"
-    "@zetachain/protocol-contracts" "11.0.0-rc5"
+    "@zetachain/protocol-contracts" "12.0.0-rc1"
     ansis "^3.3.2"
     bip39 "^3.1.0"
     bs58 "^6.0.0"
@@ -2974,7 +2987,11 @@
     ed25519-hd-key "^1.3.0"
     elliptic "6.5.7"
     ethers "^6.13.2"
+    fs-extra "^11.3.0"
     hardhat "^2.22.8"
+    js-sha256 "^0.11.0"
+    simple-git "^3.27.0"
+    sudo-prompt "^9.2.1"
     wait-on "^7.2.0"
 
 "@zetachain/networks@10.0.0", "@zetachain/networks@^10.0.0":
@@ -2983,16 +3000,6 @@
   integrity sha512-FPolaO19oVkSLSPDUA/Hu+8AhG3lDEslRDpLnMzbMbnNSC669Fkah0/TEf+6egrQbAifBRfFLzwWidAGs8oxtA==
   dependencies:
     dotenv "^16.1.4"
-
-"@zetachain/protocol-contracts@11.0.0-rc5":
-  version "11.0.0-rc5"
-  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-11.0.0-rc5.tgz#b55119e6cade29c4f266eb029d8879b968f87f63"
-  integrity sha512-+bjeTvSzuchWEIxrZ7IbOb8ERhZ+PtgmyOSSFcwhhyAOonYxNlM+1M/mSNAk5i3cdZyJTINzhk7H603/RQSeqA==
-  dependencies:
-    "@openzeppelin/contracts" "^5.0.2"
-    "@openzeppelin/contracts-upgradeable" "^5.0.2"
-    "@zetachain/networks" "^10.0.0"
-    ethers "5.6.8"
 
 "@zetachain/protocol-contracts@12.0.0-rc1":
   version "12.0.0-rc1"
@@ -5169,6 +5176,15 @@ fp-ts@^1.0.0:
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
   integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
 
+fs-extra@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
+  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
@@ -6033,6 +6049,11 @@ js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
+js-sha256@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.0.tgz#256a921d9292f7fe98905face82e367abaca9576"
+  integrity sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==
 
 js-sha3@0.5.7:
   version "0.5.7"
@@ -7289,6 +7310,15 @@ signal-exit@^4.1.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-git@^3.27.0:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.27.0.tgz#f4b09e807bda56a4a3968f635c0e4888d3decbd5"
+  integrity sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.5"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -7520,6 +7550,11 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+sudo-prompt@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-9.2.1.tgz#77efb84309c9ca489527a4e749f287e6bdd52afd"
+  integrity sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==
 
 superstruct@^0.15.4:
   version "0.15.5"


### PR DESCRIPTION
* refund gas tokens inside `onRevert` on EVM when cross-chain transfer from one connected chain to another fails. Before, the unused gas tokens remained in the NFT contract, now we're refunding them back to the sender.
* refund ZRC-20 tokens inside `onAbort` on ZetaChain when cross-chain transfer from ZetaChain to a connected chain fails.
* Removed `start` from the localnet script as it should always start localnet even without the `start` argument
* Updated localnet to `v7.1.0-rc1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error notifications during cross-chain refund operations, ensuring more precise feedback when refunds fail.

- **New Features**
  - Introduced specific error types for gas and token refund failures to improve error handling.
  - Expanded event data for token transfer events to include refund asset and amount.

- **Chores**
  - Upgraded dependency versions for improved network simulation stability.
  - Streamlined local network script behavior to simplify testing and execution flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->