### PR TITLE
fix: transfer to ZetaChain requires no gas error

### DIFF
--- a/contracts/nft/contracts/evm/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/evm/UniversalNFTCore.sol
@@ -37,6 +37,7 @@ abstract contract UniversalNFTCore is
     error Unauthorized();
     error InvalidGasLimit();
     error GasTokenTransferFailed();
+    error TransferToZetaChainRequiresNoGas();
 
     modifier onlyGateway() {
         if (msg.sender != address(gateway)) revert Unauthorized();
@@ -125,6 +126,7 @@ abstract contract UniversalNFTCore is
         emit TokenTransfer(destination, receiver, tokenId, uri);
 
         if (destination == address(0)) {
+            if (msg.value > 0) revert TransferToZetaChainRequiresNoGas();
             gateway.call(
                 universal,
                 message,

--- a/contracts/token/contracts/evm/UniversalTokenCore.sol
+++ b/contracts/token/contracts/evm/UniversalTokenCore.sol
@@ -36,7 +36,7 @@ abstract contract UniversalTokenCore is
     error Unauthorized();
     error InvalidGasLimit();
     error GasTokenTransferFailed();
-
+    error TransferToZetaChainRequiresNoGas();
     /**
      * @dev Ensures that the function can only be called by the Gateway contract.
      */
@@ -124,6 +124,7 @@ abstract contract UniversalTokenCore is
         emit TokenTransfer(destination, receiver, amount);
 
         if (destination == address(0)) {
+            if (msg.value > 0) revert TransferToZetaChainRequiresNoGas();
             gateway.call(
                 universal,
                 message,


### PR DESCRIPTION
Throw an error if the destination is ZetaChain, but `msg.value` > 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced cross-chain transfer validations to ensure that transfers to ZetaChain do not include any unintended gas. This update provides clear error notifications if an extra gas fee is attached, ensuring transfers adhere to the required conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->