### PR TITLE
fix: generate NFT IDs from block timestamp and `to` address

### DIFF
--- a/contracts/nft/contracts/evm/UniversalNFT.sol
+++ b/contracts/nft/contracts/evm/UniversalNFT.sol
@@ -55,7 +55,7 @@ contract UniversalNFT is
         // Generate globally unique token ID, feel free to supply your own logic
         uint256 hash = uint256(
             keccak256(
-                abi.encodePacked(address(this), block.number, _nextTokenId++)
+                abi.encodePacked(block.timestamp, msg.sender, _nextTokenId++)
             )
         );
 

--- a/contracts/nft/contracts/evm/UniversalNFT.sol
+++ b/contracts/nft/contracts/evm/UniversalNFT.sol
@@ -54,9 +54,7 @@ contract UniversalNFT is
     ) public onlyOwner whenNotPaused {
         // Generate globally unique token ID, feel free to supply your own logic
         uint256 hash = uint256(
-            keccak256(
-                abi.encodePacked(block.timestamp, msg.sender, _nextTokenId++)
-            )
+            keccak256(abi.encodePacked(block.timestamp, to, _nextTokenId++))
         );
 
         uint256 tokenId = hash & 0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;

--- a/contracts/nft/contracts/zetachain/UniversalNFT.sol
+++ b/contracts/nft/contracts/zetachain/UniversalNFT.sol
@@ -55,9 +55,7 @@ contract UniversalNFT is
     ) public onlyOwner whenNotPaused {
         // Generate globally unique token ID, feel free to supply your own logic
         uint256 hash = uint256(
-            keccak256(
-                abi.encodePacked(block.timestamp, msg.sender, _nextTokenId++)
-            )
+            keccak256(abi.encodePacked(block.timestamp, to, _nextTokenId++))
         );
 
         uint256 tokenId = hash & 0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;

--- a/contracts/nft/contracts/zetachain/UniversalNFT.sol
+++ b/contracts/nft/contracts/zetachain/UniversalNFT.sol
@@ -56,7 +56,7 @@ contract UniversalNFT is
         // Generate globally unique token ID, feel free to supply your own logic
         uint256 hash = uint256(
             keccak256(
-                abi.encodePacked(address(this), block.number, _nextTokenId++)
+                abi.encodePacked(block.timestamp, msg.sender, _nextTokenId++)
             )
         );
 


### PR DESCRIPTION
Closes https://github.com/zeta-chain/protocol-private/issues/292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the uniqueness of token IDs generated during NFT minting by updating the underlying logic to use the current block timestamp and recipient address. No changes to user-facing features or interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->