### PR TITLE
Solana: Universal NFT Anchor program with Gateway on_call/on_revert + payload tooling

### DIFF
--- a/contracts/nft/contracts/solana/universal_nft/Anchor.toml
+++ b/contracts/nft/contracts/solana/universal_nft/Anchor.toml
@@ -1,0 +1,26 @@
+[features]
+seeds = true
+
+[programs.localnet]
+universal_nft = "Un1v3rsa1Nft111111111111111111111111111111"
+
+[programs.devnet]
+universal_nft = "Un1v3rsa1Nft111111111111111111111111111111"
+
+[programs.testnet]
+universal_nft = "Un1v3rsa1Nft111111111111111111111111111111"
+
+[programs.mainnet]
+universal_nft = "Un1v3rsa1Nft111111111111111111111111111111"
+
+[registry]
+url = "https://anchor.projectserum.com"
+
+[provider]
+cluster = "testnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+build = "anchor build"
+deploy = "anchor deploy"
+idl = "anchor idl"

--- a/contracts/nft/contracts/solana/universal_nft/Cargo.toml
+++ b/contracts/nft/contracts/solana/universal_nft/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "universal_nft"
+version = "0.1.0"
+description = "Solana Universal NFT Program for Interoperability with ZetaChain"
+edition = "2021"
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "universal_nft"
+
+[features]
+no-entrypoint = []
+idl-build = ["anchor-lang/idl-build"]
+default = []
+
+[dependencies]
+anchor-lang = "0.30.1"
+anchor-spl = { version = "0.30.1", features = ["token", "associated_token"] }
+borsh = "0.10"
+borsh-derive = "0.10"
+mpl-token-metadata = { version = "1.14.3", features = ["no-entrypoint"] }

--- a/contracts/nft/contracts/solana/universal_nft/README.md
+++ b/contracts/nft/contracts/solana/universal_nft/README.md
@@ -1,0 +1,181 @@
+# Solana Universal NFT  
+Cross-Chain NFT Program for ZetaChain Interoperability
+---
+
+## Overview  
+Universal NFT lets any NFT move freely between Solana, ZetaChain, and all connected EVM / non-EVM chains.
+
+* Burn-and-mint model – NFT is burned on the source chain, re-minted on the destination.  
+* Metadata, collection and ownership are preserved across chains.  
+* Each deployment forms its own **collection**; NFTs minted by that program are members of that collection.
+
+---
+
+## Architecture  
+
+| Component | Purpose |
+|-----------|---------|
+| **Anchor program `universal_nft`** | Core on-chain logic (Solana). |
+| **PDAs** | `config`, `treasury`, `mint_auth`, `nft_origin`, `processed_message`. |
+| **Collection mint** | Created in `initialize`, supplies 1 token held by `treasury`. |
+| **Payload (Borsh)** | ```struct Payload { token_id\[32\]; name; symbol; uri; recipient; origin_chain_id; nonce; original_solana_mint? }``` – passed through Gateway `withdrawAndCall`. |
+| **Gateway program** | `ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis` – verified in every inbound call. |
+
+### Instruction Flow  
+
+1. **initialize** → deploy program, create collection mint, PDAs.  
+2. **mint_local** → mint NFT on Solana, create `nft_origin` PDA.  
+3. **burn_and_prepare** → burn, emit event; client encodes `Payload`, calls Gateway `deposit_and_call`.  
+4. **Gateway → on_call** → program validates caller, decodes payload, mints NFT to `recipient`.  
+5. **on_revert** (optional) → handles revert paths from ZetaChain.
+
+---
+
+## Gateway Integration  
+
+* Program implements `on_call` & `on_revert` per Gateway spec.  
+* Verification:
+  * Previous instruction’s `program_id` == Gateway program id.
+  * `gateway_meta` PDA (seed `b"meta"`) matches expected address.
+  * Replay protected with `processed_message` PDA (seeded by `sender|token_id|nonce`).
+
+Expected accounts for `on_call`:
+```
+config, mint_auth, nft_origin (init/exists), processed_message (init/exists),
+mint (init), token_account (init ATA),
+gateway_meta, payer, system, token, associated_token, rent, sysvar::instructions
+```
+
+---
+
+## Setup  
+
+### Prerequisites  
+* Rust `stable` + `cargo-build-sbf` (v1.79 or newer)  
+* Solana CLI ≥ 1.18  
+* Anchor CLI ≥ 0.30  
+* Node ≥ 18 (for scripts)  
+* A funded Solana **testnet** keypair (`~/.config/solana/id.json` by default)
+
+### Build & Deploy (testnet default)  
+```bash
+git clone https://github.com/zeta-chain/standard-contracts.git
+cd standard-contracts/contracts/nft/contracts/solana/universal_nft
+anchor build          # produces target/deploy/universal_nft.so
+anchor deploy         # deploys to Solana testnet as per Anchor.toml
+```
+To switch cluster: `anchor deploy --provider.cluster devnet`.
+
+### Funding Wallet  
+```
+solana airdrop 2 --url https://api.testnet.solana.com
+```
+
+---
+
+## Usage  
+
+### 1. Initialize collection  
+```bash
+anchor run initialize \
+  -- --collection-name "Universal Apes" \
+     --collection-symbol "UAPE" \
+     --collection-uri "https://example.com/metadata.json"
+```
+
+### 2. Mint local NFT  
+```bash
+anchor run mint_local \
+  -- --name "Ape #1" --symbol "UAPE" --uri "https://example.com/1.json" \
+     --recipient <RECIPIENT_PUBKEY>
+```
+
+### 3. Burn & send cross-chain  
+```bash
+anchor run burn_and_prepare -- --mint <NFT_MINT>
+# Script prints emitted token_id, then:
+ts-node scripts/sendToZeta.ts <token_id> <name> <symbol> <uri> <recipientEvmAddr>
+```
+`sendToZeta.ts`:
+```ts
+import { Payload } from "./payload";
+const payload = Payload.encode({...});
+gateway.depositAndCall(ZRC20_NULL, 0, payload, ...);
+```
+
+### 4. Receive on Solana (automatic)  
+ZetaChain observers execute `withdrawAndCall`; Gateway calls `on_call`; NFT appears in recipient ATA.
+
+---
+
+## Security Notes  
+
+* **Replay protection** – processed messages recorded in PDA.  
+* **Caller auth** – verifies Gateway program & meta PDA via `sysvar::instructions`.  
+* **Signer model** – mint authority & treasury are PDAs signed with seeds.  
+* **Rent** – treasury PDA prefunded by admin (lamports flow from `payer`).  
+* **Compute budget** – heavy minting CPIs require ~200k CU; add before minting:  
+  `solana compute-budget increase-cu 200000`.
+
+---
+
+## Configuration  
+
+Create `.env` (not committed):
+
+```
+SOLANA_CLUSTER=https://api.testnet.solana.com
+ZETA_RPC_TESTNET=https://zetachain-testnet.node
+ETH_RPC_BASE_SEPOLIA=<url>
+WALLET_PRIVATE_KEY=<base58>
+```
+
+Scripts read env for cross-chain tests.
+
+---
+
+## Devnet vs Testnet  
+
+* **Default** Anchor.toml targets `testnet` (closer to ZetaChain testnet).  
+* For purely local demos or free airdrops, deploy to `devnet`:
+  `anchor deploy --provider.cluster devnet`.  
+* Gateway id is identical on devnet/testnet/mainnet.
+
+---
+
+## Example TS Payload Encoding  
+
+```ts
+import { struct, u32, u64, blob, str } from "@solana/buffer-layout";
+import { publicKey } from "@solana/buffer-layout-utils";
+
+export const Payload = struct([
+  blob(32, "token_id"),
+  str("name"),
+  str("symbol"),
+  str("uri"),
+  publicKey("recipient"),
+  u32("origin_chain_id"),
+  u64("nonce"),
+  publicKey("original_solana_mint", true) // option
+]);
+
+const data = Payload.encode({
+  token_id,
+  name: "Ape #1",
+  symbol: "UAPE",
+  uri: "https://example.com/1.json",
+  recipient: new PublicKey("<SOL_PUBKEY>").toBytes(),
+  origin_chain_id: 7000,   // example ZEVM chain id
+  nonce: Date.now(),
+  original_solana_mint: null
+});
+```
+
+Send `data` as the `message` argument to Gateway `depositAndCall`.
+
+---
+
+## License  
+MIT  
+© 2025 ZetaChain contributors

--- a/contracts/nft/contracts/solana/universal_nft/programs/universal_nft/src/lib.rs
+++ b/contracts/nft/contracts/solana/universal_nft/programs/universal_nft/src/lib.rs
@@ -1,0 +1,1069 @@
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{
+    instruction::Instruction,
+    program::{invoke, invoke_signed},
+    pubkey::Pubkey,
+    system_instruction,
+    sysvar::{instructions::Instructions, SysvarId},
+};
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token::{burn, mint_to, Burn, Mint, MintTo, Token, TokenAccount},
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use mpl_token_metadata::{
+    instruction::{
+        builders::{
+            CreateMasterEditionV3Builder, CreateMetadataAccountV3Builder, SetAndVerifyCollectionBuilder,
+        },
+        InstructionBuilder,
+    },
+    state::{Collection, Creator, DataV2, Metadata},
+    ID as MetadataID,
+};
+
+declare_id!("Un1v3rsa1Nft111111111111111111111111111111");
+
+const GATEWAY_PROGRAM_ID: Pubkey = 
+    solana_program::pubkey!("ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis");
+
+mod state {
+    use super::*;
+
+    #[account]
+    pub struct Config {
+        pub admin: Pubkey,
+        pub treasury: Pubkey,
+        pub mint_auth: Pubkey,
+        pub collection_mint: Pubkey,
+        pub bumps: ConfigBumps,
+        pub next_token_id: u64,
+    }
+
+    #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy)]
+    pub struct ConfigBumps {
+        pub config: u8,
+        pub treasury: u8,
+        pub mint_auth: u8,
+    }
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    pub struct NftOrigin {
+        pub token_id: [u8; 32],
+        pub original_solana_mint: Option<Pubkey>,
+        pub mint_count: u64,
+    }
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    pub struct ProcessedMessage {
+        pub sender: [u8; 20],
+        pub token_id: [u8; 32],
+        pub nonce: u64,
+    }
+}
+
+mod payload {
+    use super::*;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    pub struct Payload {
+        pub token_id: [u8; 32],
+        pub name: String,
+        pub symbol: String,
+        pub uri: String,
+        pub recipient: Pubkey,
+        pub origin_chain_id: u32,
+        pub nonce: u64,
+        pub original_solana_mint: Option<Pubkey>,
+    }
+}
+
+mod utils {
+    use super::*;
+
+    pub fn check_gateway(instructions_sysvar: &AccountInfo) -> Result<()> {
+        let ix_sysvar = Instructions::from_account_info(instructions_sysvar)?;
+        let current_ix = Instructions::get_instruction_at(&ix_sysvar, 0)?;
+        require!(
+            current_ix.program_id == crate::ID,
+            ErrorCode::InvalidGatewayProgram
+        );
+
+        let prev_ix = Instructions::get_instruction_at(&ix_sysvar, 1)?;
+        require!(
+            prev_ix.program_id == GATEWAY_PROGRAM_ID,
+            ErrorCode::InvalidGatewayProgram
+        );
+
+        Ok(())
+    }
+
+    pub fn ensure_account_initialized(account: &AccountInfo) -> bool {
+        account.data_len() > 0 && !account.data_is_empty()
+    }
+
+    pub fn create_pda_account<T: BorshSerialize>(
+        payer: &AccountInfo,
+        new_account: &AccountInfo,
+        space: usize,
+        seeds: &[&[u8]],
+        bump: u8,
+        owner: &Pubkey,
+        system_program: &AccountInfo,
+        data: T,
+    ) -> Result<()> {
+        let seeds_with_bump = [seeds, &[&[bump]]].concat();
+        let seeds_slice = seeds_with_bump.iter().map(|s| s.as_slice()).collect::<Vec<_>>();
+
+        invoke_signed(
+            &system_instruction::create_account(
+                payer.key,
+                new_account.key,
+                Rent::get()?.minimum_balance(space),
+                space as u64,
+                owner,
+            ),
+            &[payer.clone(), new_account.clone(), system_program.clone()],
+            &[&seeds_slice[..]],
+        )?;
+
+        let mut data_ref = new_account.try_borrow_mut_data()?;
+        data.serialize(&mut *data_ref)?;
+
+        Ok(())
+    }
+
+    pub fn get_ata(wallet: &Pubkey, mint: &Pubkey) -> (Pubkey, u8) {
+        anchor_spl::associated_token::get_associated_token_address(wallet, mint)
+    }
+
+    pub fn create_ata(
+        payer: &AccountInfo,
+        wallet: &AccountInfo,
+        mint: &AccountInfo,
+        system_program: &AccountInfo,
+        token_program: &AccountInfo,
+        associated_token_program: &AccountInfo,
+        rent: &AccountInfo,
+    ) -> Result<()> {
+        invoke(
+            &associated_token::create_associated_token_account(
+                payer.key,
+                wallet.key,
+                mint.key,
+                &anchor_spl::token::ID,
+            ),
+            &[
+                payer.clone(),
+                wallet.clone(),
+                mint.clone(),
+                system_program.clone(),
+                token_program.clone(),
+                associated_token_program.clone(),
+                rent.clone(),
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    pub fn create_metadata(
+        metadata_account: &AccountInfo,
+        mint: &AccountInfo,
+        mint_authority: &AccountInfo,
+        payer: &AccountInfo,
+        update_authority: &AccountInfo,
+        system_program: &AccountInfo,
+        rent: &AccountInfo,
+        name: String,
+        symbol: String,
+        uri: String,
+        creators: Option<Vec<Creator>>,
+        seller_fee_basis_points: u16,
+        update_authority_is_signer: bool,
+        is_mutable: bool,
+        collection: Option<Collection>,
+        uses: Option<mpl_token_metadata::state::Uses>,
+        signer_seeds: &[&[&[u8]]],
+    ) -> Result<()> {
+        let data_v2 = DataV2 {
+            name,
+            symbol,
+            uri,
+            seller_fee_basis_points,
+            creators,
+            collection,
+            uses,
+        };
+
+        let ix = CreateMetadataAccountV3Builder::new()
+            .metadata(metadata_account.key())
+            .mint(mint.key())
+            .mint_authority(mint_authority.key())
+            .payer(payer.key())
+            .update_authority(update_authority.key(), update_authority_is_signer)
+            .data(data_v2)
+            .is_mutable(is_mutable)
+            .build()
+            .unwrap()
+            .instruction();
+
+        invoke_signed(
+            &ix,
+            &[
+                metadata_account.clone(),
+                mint.clone(),
+                mint_authority.clone(),
+                payer.clone(),
+                update_authority.clone(),
+                system_program.clone(),
+                rent.clone(),
+            ],
+            signer_seeds,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn create_master_edition(
+        edition_account: &AccountInfo,
+        mint: &AccountInfo,
+        update_authority: &AccountInfo,
+        mint_authority: &AccountInfo,
+        metadata: &AccountInfo,
+        payer: &AccountInfo,
+        system_program: &AccountInfo,
+        rent: &AccountInfo,
+        token_program: &AccountInfo,
+        max_supply: Option<u64>,
+        signer_seeds: &[&[&[u8]]],
+    ) -> Result<()> {
+        let ix = CreateMasterEditionV3Builder::new()
+            .edition(edition_account.key())
+            .mint(mint.key())
+            .update_authority(update_authority.key())
+            .mint_authority(mint_authority.key())
+            .metadata(metadata.key())
+            .payer(payer.key())
+            .max_supply(max_supply)
+            .build()
+            .unwrap()
+            .instruction();
+
+        invoke_signed(
+            &ix,
+            &[
+                edition_account.clone(),
+                mint.clone(),
+                update_authority.clone(),
+                mint_authority.clone(),
+                metadata.clone(),
+                payer.clone(),
+                system_program.clone(),
+                rent.clone(),
+                token_program.clone(),
+            ],
+            signer_seeds,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn set_and_verify_collection(
+        metadata: &AccountInfo,
+        collection_authority: &AccountInfo,
+        payer: &AccountInfo,
+        update_authority: &AccountInfo,
+        collection_mint: &AccountInfo,
+        collection_metadata: &AccountInfo,
+        collection_master_edition: &AccountInfo,
+        system_program: &AccountInfo,
+        signer_seeds: &[&[&[u8]]],
+    ) -> Result<()> {
+        let ix = SetAndVerifyCollectionBuilder::new()
+            .metadata(metadata.key())
+            .collection_authority(collection_authority.key())
+            .payer(payer.key())
+            .update_authority(update_authority.key())
+            .collection_mint(collection_mint.key())
+            .collection(collection_metadata.key())
+            .collection_master_edition(collection_master_edition.key())
+            .collection_authority_record(None)
+            .build()
+            .unwrap()
+            .instruction();
+
+        invoke_signed(
+            &ix,
+            &[
+                metadata.clone(),
+                collection_authority.clone(),
+                payer.clone(),
+                update_authority.clone(),
+                collection_mint.clone(),
+                collection_metadata.clone(),
+                collection_master_edition.clone(),
+                system_program.clone(),
+            ],
+            signer_seeds,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Unauthorized")]
+    Unauthorized,
+    #[msg("Invalid Gateway Program")]
+    InvalidGatewayProgram,
+    #[msg("Invalid Gateway Meta")]
+    InvalidGatewayMeta,
+    #[msg("Message Already Processed")]
+    MessageAlreadyProcessed,
+    #[msg("Invalid Token ID")]
+    InvalidTokenId,
+    #[msg("Invalid Mint")]
+    InvalidMint,
+    #[msg("Invalid Owner")]
+    InvalidOwner,
+    #[msg("Account Not Initialized")]
+    AccountNotInitialized,
+}
+
+#[event]
+pub struct OutboundPrepared {
+    pub token_id: [u8; 32],
+    pub mint: Pubkey,
+}
+
+#[event]
+pub struct InboundReceived {
+    pub token_id: [u8; 32],
+    pub mint: Pubkey,
+    pub recipient: Pubkey,
+    pub sender: [u8; 20],
+    pub origin_chain_id: u32,
+}
+
+#[program]
+pub mod universal_nft {
+    use super::*;
+
+    pub fn initialize(
+        ctx: Context<Initialize>,
+        admin: Pubkey,
+        collection_name: String,
+        collection_symbol: String,
+        collection_uri: String,
+    ) -> Result<()> {
+        let config = &mut ctx.accounts.config;
+        config.admin = admin;
+        config.treasury = ctx.accounts.treasury.key();
+        config.mint_auth = ctx.accounts.mint_auth.key();
+        config.collection_mint = ctx.accounts.collection_mint.key();
+        config.bumps = ctx.bumps.into();
+        config.next_token_id = 1;
+
+        // Create collection mint
+        let mint_auth_seeds = &[b"mint_auth", &[ctx.bumps.mint_auth]];
+        let mint_auth_signer = &[&mint_auth_seeds[..]];
+
+        // Mint 1 token to treasury
+        let cpi_accounts = MintTo {
+            mint: ctx.accounts.collection_mint.to_account_info(),
+            to: ctx.accounts.treasury_token_account.to_account_info(),
+            authority: ctx.accounts.mint_auth.to_account_info(),
+        };
+        let cpi_program = ctx.accounts.token_program.to_account_info();
+        let cpi_ctx = CpiContext::new_with_signer(cpi_program, cpi_accounts, mint_auth_signer);
+        mint_to(cpi_ctx, 1)?;
+
+        // Create metadata
+        let metadata_seeds = &[b"metadata", MetadataID.as_ref(), ctx.accounts.collection_mint.key().as_ref()];
+        let (metadata_key, _) = Pubkey::find_program_address(metadata_seeds, &MetadataID);
+        require!(metadata_key == ctx.accounts.collection_metadata.key(), ErrorCode::InvalidMint);
+
+        utils::create_metadata(
+            &ctx.accounts.collection_metadata,
+            &ctx.accounts.collection_mint.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &ctx.accounts.rent.to_account_info(),
+            collection_name,
+            collection_symbol,
+            collection_uri,
+            None,
+            0,
+            false,
+            true,
+            None,
+            None,
+            mint_auth_signer,
+        )?;
+
+        // Create master edition
+        let edition_seeds = &[
+            b"metadata", 
+            MetadataID.as_ref(), 
+            ctx.accounts.collection_mint.key().as_ref(), 
+            b"edition"
+        ];
+        let (edition_key, _) = Pubkey::find_program_address(edition_seeds, &MetadataID);
+        require!(edition_key == ctx.accounts.collection_master_edition.key(), ErrorCode::InvalidMint);
+
+        utils::create_master_edition(
+            &ctx.accounts.collection_master_edition,
+            &ctx.accounts.collection_mint.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.collection_metadata,
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &ctx.accounts.rent.to_account_info(),
+            &ctx.accounts.token_program.to_account_info(),
+            Some(0),
+            mint_auth_signer,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn mint_local(
+        ctx: Context<MintLocal>,
+        name: String,
+        symbol: String,
+        uri: String,
+    ) -> Result<()> {
+        let config = &mut ctx.accounts.config;
+        
+        // Generate token_id from mint pubkey, slot, and next_token_id
+        let slot = Clock::get()?.slot;
+        let mut token_id_data = Vec::new();
+        token_id_data.extend_from_slice(&ctx.accounts.mint.key().to_bytes());
+        token_id_data.extend_from_slice(&slot.to_le_bytes());
+        token_id_data.extend_from_slice(&config.next_token_id.to_le_bytes());
+        
+        let token_id = anchor_lang::solana_program::hash::hash(&token_id_data).to_bytes();
+        config.next_token_id += 1;
+
+        // Create NFT origin record
+        let nft_origin_seeds = &[b"nft_origin", &token_id];
+        let (_, nft_origin_bump) = Pubkey::find_program_address(nft_origin_seeds, &crate::ID);
+        
+        let nft_origin_data = state::NftOrigin {
+            token_id,
+            original_solana_mint: Some(ctx.accounts.mint.key()),
+            mint_count: 1,
+        };
+        
+        utils::create_pda_account(
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.nft_origin,
+            std::mem::size_of::<state::NftOrigin>(),
+            nft_origin_seeds,
+            nft_origin_bump,
+            &crate::ID,
+            &ctx.accounts.system_program.to_account_info(),
+            nft_origin_data,
+        )?;
+
+        // Mint token
+        let mint_auth_seeds = &[b"mint_auth", &[ctx.bumps.mint_auth]];
+        let mint_auth_signer = &[&mint_auth_seeds[..]];
+
+        let cpi_accounts = MintTo {
+            mint: ctx.accounts.mint.to_account_info(),
+            to: ctx.accounts.token_account.to_account_info(),
+            authority: ctx.accounts.mint_auth.to_account_info(),
+        };
+        let cpi_program = ctx.accounts.token_program.to_account_info();
+        let cpi_ctx = CpiContext::new_with_signer(cpi_program, cpi_accounts, mint_auth_signer);
+        mint_to(cpi_ctx, 1)?;
+
+        // Create metadata
+        let metadata_seeds = &[b"metadata", MetadataID.as_ref(), ctx.accounts.mint.key().as_ref()];
+        let (metadata_key, _) = Pubkey::find_program_address(metadata_seeds, &MetadataID);
+        require!(metadata_key == ctx.accounts.metadata.key(), ErrorCode::InvalidMint);
+
+        let collection = Collection {
+            verified: false,
+            key: ctx.accounts.config.collection_mint,
+        };
+
+        utils::create_metadata(
+            &ctx.accounts.metadata,
+            &ctx.accounts.mint.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &ctx.accounts.rent.to_account_info(),
+            name,
+            symbol,
+            uri,
+            None,
+            0,
+            false,
+            true,
+            Some(collection),
+            None,
+            mint_auth_signer,
+        )?;
+
+        // Create master edition
+        let edition_seeds = &[
+            b"metadata", 
+            MetadataID.as_ref(), 
+            ctx.accounts.mint.key().as_ref(), 
+            b"edition"
+        ];
+        let (edition_key, _) = Pubkey::find_program_address(edition_seeds, &MetadataID);
+        require!(edition_key == ctx.accounts.master_edition.key(), ErrorCode::InvalidMint);
+
+        utils::create_master_edition(
+            &ctx.accounts.master_edition,
+            &ctx.accounts.mint.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.metadata,
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &ctx.accounts.rent.to_account_info(),
+            &ctx.accounts.token_program.to_account_info(),
+            Some(0),
+            mint_auth_signer,
+        )?;
+
+        // Set and verify collection
+        utils::set_and_verify_collection(
+            &ctx.accounts.metadata,
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.collection_mint.to_account_info(),
+            &ctx.accounts.collection_metadata,
+            &ctx.accounts.collection_master_edition,
+            &ctx.accounts.system_program.to_account_info(),
+            mint_auth_signer,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn burn_and_prepare(ctx: Context<BurnAndPrepare>) -> Result<()> {
+        // Read token_id from NftOrigin
+        let nft_origin_data = ctx.accounts.nft_origin.try_borrow_data()?;
+        let nft_origin = state::NftOrigin::try_from_slice(&nft_origin_data)?;
+        
+        // Verify the mint exists in NftOrigin
+        require!(
+            nft_origin.original_solana_mint.is_some() && 
+            nft_origin.original_solana_mint.unwrap() == ctx.accounts.mint.key(),
+            ErrorCode::InvalidMint
+        );
+
+        // Burn the token
+        let cpi_accounts = Burn {
+            mint: ctx.accounts.mint.to_account_info(),
+            from: ctx.accounts.token_account.to_account_info(),
+            authority: ctx.accounts.owner.to_account_info(),
+        };
+        let cpi_program = ctx.accounts.token_program.to_account_info();
+        let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+        burn(cpi_ctx, 1)?;
+
+        // Emit event with token_id and mint
+        emit!(OutboundPrepared {
+            token_id: nft_origin.token_id,
+            mint: ctx.accounts.mint.key(),
+        });
+
+        Ok(())
+    }
+
+    pub fn on_call(
+        ctx: Context<OnCall>,
+        sender: [u8; 20],
+        amount: u64,
+        data: Vec<u8>,
+    ) -> Result<()> {
+        // Verify the previous instruction was from the Gateway program
+        utils::check_gateway(&ctx.accounts.instructions.to_account_info())?;
+
+        // Verify gateway meta account
+        let gateway_meta_seeds = &[b"meta"];
+        let (expected_gateway_meta, _) = Pubkey::find_program_address(gateway_meta_seeds, &GATEWAY_PROGRAM_ID);
+        require!(
+            ctx.accounts.gateway_meta.key() == expected_gateway_meta,
+            ErrorCode::InvalidGatewayMeta
+        );
+
+        // Decode payload
+        let payload = payload::Payload::try_from_slice(&data)?;
+
+        // Check if message already processed
+        let processed_message_seeds = &[
+            b"processed", 
+            &sender, 
+            &payload.token_id,
+            &payload.nonce.to_le_bytes()
+        ];
+        let (processed_message_key, processed_message_bump) = 
+            Pubkey::find_program_address(processed_message_seeds, &crate::ID);
+        
+        require!(
+            processed_message_key == ctx.accounts.processed_message.key(),
+            ErrorCode::InvalidMint
+        );
+        
+        let is_processed_empty = ctx.accounts.processed_message.data_is_empty();
+        
+        if !is_processed_empty {
+            // Read existing processed message and verify it's not a replay
+            let processed_data = ctx.accounts.processed_message.try_borrow_data()?;
+            let processed = state::ProcessedMessage::try_from_slice(&processed_data)?;
+            
+            require!(
+                processed.sender != sender ||
+                processed.token_id != payload.token_id ||
+                processed.nonce != payload.nonce,
+                ErrorCode::MessageAlreadyProcessed
+            );
+        }
+        
+        // Create processed message record
+        let processed_message_data = state::ProcessedMessage {
+            sender,
+            token_id: payload.token_id,
+            nonce: payload.nonce,
+        };
+        
+        if is_processed_empty {
+            utils::create_pda_account(
+                &ctx.accounts.payer.to_account_info(),
+                &ctx.accounts.processed_message,
+                std::mem::size_of::<state::ProcessedMessage>(),
+                processed_message_seeds,
+                processed_message_bump,
+                &crate::ID,
+                &ctx.accounts.system_program.to_account_info(),
+                processed_message_data,
+            )?;
+        }
+
+        // Check if NFT origin exists
+        let nft_origin_seeds = &[b"nft_origin", &payload.token_id];
+        let (nft_origin_key, nft_origin_bump) = 
+            Pubkey::find_program_address(nft_origin_seeds, &crate::ID);
+        
+        require!(
+            nft_origin_key == ctx.accounts.nft_origin.key(),
+            ErrorCode::InvalidMint
+        );
+        
+        let is_nft_origin_empty = ctx.accounts.nft_origin.data_is_empty();
+        
+        let nft_origin_data = if is_nft_origin_empty {
+            // Initialize new NFT origin
+            state::NftOrigin {
+                token_id: payload.token_id,
+                original_solana_mint: payload.original_solana_mint,
+                mint_count: 1,
+            }
+        } else {
+            // Read and update existing NFT origin
+            let nft_origin_existing = ctx.accounts.nft_origin.try_borrow_data()?;
+            let mut nft_origin = state::NftOrigin::try_from_slice(&nft_origin_existing)?;
+            
+            require!(
+                nft_origin.token_id == payload.token_id,
+                ErrorCode::InvalidTokenId
+            );
+            
+            nft_origin.mint_count += 1;
+            nft_origin
+        };
+        
+        if is_nft_origin_empty {
+            utils::create_pda_account(
+                &ctx.accounts.payer.to_account_info(),
+                &ctx.accounts.nft_origin,
+                std::mem::size_of::<state::NftOrigin>(),
+                nft_origin_seeds,
+                nft_origin_bump,
+                &crate::ID,
+                &ctx.accounts.system_program.to_account_info(),
+                nft_origin_data,
+            )?;
+        } else {
+            let mut nft_origin_ref = ctx.accounts.nft_origin.try_borrow_mut_data()?;
+            nft_origin_data.serialize(&mut *nft_origin_ref)?;
+        }
+
+        // Create ATA if it doesn't exist
+        let recipient_ata = utils::get_ata(&payload.recipient, &ctx.accounts.mint.key());
+        
+        if ctx.accounts.token_account.data_is_empty() {
+            utils::create_ata(
+                &ctx.accounts.payer.to_account_info(),
+                &ctx.accounts.recipient.to_account_info(),
+                &ctx.accounts.mint.to_account_info(),
+                &ctx.accounts.system_program.to_account_info(),
+                &ctx.accounts.token_program.to_account_info(),
+                &ctx.accounts.associated_token_program.to_account_info(),
+                &ctx.accounts.rent.to_account_info(),
+            )?;
+        }
+
+        // Mint token
+        let mint_auth_seeds = &[b"mint_auth", &[ctx.bumps.mint_auth]];
+        let mint_auth_signer = &[&mint_auth_seeds[..]];
+
+        let cpi_accounts = MintTo {
+            mint: ctx.accounts.mint.to_account_info(),
+            to: ctx.accounts.token_account.to_account_info(),
+            authority: ctx.accounts.mint_auth.to_account_info(),
+        };
+        let cpi_program = ctx.accounts.token_program.to_account_info();
+        let cpi_ctx = CpiContext::new_with_signer(cpi_program, cpi_accounts, mint_auth_signer);
+        mint_to(cpi_ctx, 1)?;
+
+        // Create metadata
+        let metadata_seeds = &[b"metadata", MetadataID.as_ref(), ctx.accounts.mint.key().as_ref()];
+        let (metadata_key, _) = Pubkey::find_program_address(metadata_seeds, &MetadataID);
+        require!(metadata_key == ctx.accounts.metadata.key(), ErrorCode::InvalidMint);
+
+        let collection = Collection {
+            verified: false,
+            key: ctx.accounts.config.collection_mint,
+        };
+
+        utils::create_metadata(
+            &ctx.accounts.metadata,
+            &ctx.accounts.mint.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &ctx.accounts.rent.to_account_info(),
+            payload.name,
+            payload.symbol,
+            payload.uri,
+            None,
+            0,
+            false,
+            true,
+            Some(collection),
+            None,
+            mint_auth_signer,
+        )?;
+
+        // Create master edition
+        let edition_seeds = &[
+            b"metadata", 
+            MetadataID.as_ref(), 
+            ctx.accounts.mint.key().as_ref(), 
+            b"edition"
+        ];
+        let (edition_key, _) = Pubkey::find_program_address(edition_seeds, &MetadataID);
+        require!(edition_key == ctx.accounts.master_edition.key(), ErrorCode::InvalidMint);
+
+        utils::create_master_edition(
+            &ctx.accounts.master_edition,
+            &ctx.accounts.mint.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.metadata,
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &ctx.accounts.rent.to_account_info(),
+            &ctx.accounts.token_program.to_account_info(),
+            Some(0),
+            mint_auth_signer,
+        )?;
+
+        // Set and verify collection
+        utils::set_and_verify_collection(
+            &ctx.accounts.metadata,
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.payer.to_account_info(),
+            &ctx.accounts.mint_auth.to_account_info(),
+            &ctx.accounts.collection_mint.to_account_info(),
+            &ctx.accounts.collection_metadata,
+            &ctx.accounts.collection_master_edition,
+            &ctx.accounts.system_program.to_account_info(),
+            mint_auth_signer,
+        )?;
+
+        // Emit event
+        emit!(InboundReceived {
+            token_id: payload.token_id,
+            mint: ctx.accounts.mint.key(),
+            recipient: payload.recipient,
+            sender,
+            origin_chain_id: payload.origin_chain_id,
+        });
+
+        Ok(())
+    }
+
+    pub fn on_revert(
+        ctx: Context<OnRevert>,
+        sender: [u8; 20],
+        data: Vec<u8>,
+    ) -> Result<()> {
+        // Verify the previous instruction was from the Gateway program
+        utils::check_gateway(&ctx.accounts.instructions.to_account_info())?;
+
+        // Verify gateway meta account
+        let gateway_meta_seeds = &[b"meta"];
+        let (expected_gateway_meta, _) = Pubkey::find_program_address(gateway_meta_seeds, &GATEWAY_PROGRAM_ID);
+        require!(
+            ctx.accounts.gateway_meta.key() == expected_gateway_meta,
+            ErrorCode::InvalidGatewayMeta
+        );
+
+        // Handle revert logic if needed
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(admin: Pubkey, collection_name: String, collection_symbol: String, collection_uri: String)]
+pub struct Initialize<'info> {
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + std::mem::size_of::<state::Config>(),
+        seeds = [b"config"],
+        bump
+    )]
+    pub config: Account<'info, state::Config>,
+
+    #[account(
+        init,
+        payer = payer,
+        space = 8,
+        seeds = [b"treasury"],
+        bump
+    )]
+    pub treasury: SystemAccount<'info>,
+
+    #[account(
+        init,
+        payer = payer,
+        space = 8,
+        seeds = [b"mint_auth"],
+        bump
+    )]
+    pub mint_auth: SystemAccount<'info>,
+
+    #[account(
+        init,
+        payer = payer,
+        mint::decimals = 0,
+        mint::authority = mint_auth,
+    )]
+    pub collection_mint: Account<'info, Mint>,
+
+    #[account(
+        init,
+        payer = payer,
+        associated_token::mint = collection_mint,
+        associated_token::authority = treasury,
+    )]
+    pub treasury_token_account: Account<'info, TokenAccount>,
+    
+    /// CHECK: Metadata account for collection
+    #[account(mut)]
+    pub collection_metadata: UncheckedAccount<'info>,
+    
+    /// CHECK: Master edition account for collection
+    #[account(mut)]
+    pub collection_master_edition: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+#[instruction(name: String, symbol: String, uri: String)]
+pub struct MintLocal<'info> {
+    #[account(mut)]
+    pub config: Account<'info, state::Config>,
+
+    #[account(
+        seeds = [b"mint_auth"],
+        bump = config.bumps.mint_auth,
+    )]
+    pub mint_auth: SystemAccount<'info>,
+    
+    /// CHECK: NFT origin PDA, will be initialized in handler
+    #[account(mut)]
+    pub nft_origin: UncheckedAccount<'info>,
+
+    #[account(
+        init,
+        payer = payer,
+        mint::decimals = 0,
+        mint::authority = mint_auth,
+    )]
+    pub mint: Account<'info, Mint>,
+
+    #[account(
+        init,
+        payer = payer,
+        associated_token::mint = mint,
+        associated_token::authority = recipient,
+    )]
+    pub token_account: Account<'info, TokenAccount>,
+    
+    /// CHECK: Metadata account for NFT
+    #[account(mut)]
+    pub metadata: UncheckedAccount<'info>,
+    
+    /// CHECK: Master edition account for NFT
+    #[account(mut)]
+    pub master_edition: UncheckedAccount<'info>,
+    
+    /// CHECK: Collection mint from config
+    #[account(
+        constraint = collection_mint.key() == config.collection_mint
+    )]
+    pub collection_mint: Account<'info, Mint>,
+    
+    /// CHECK: Collection metadata
+    #[account(mut)]
+    pub collection_metadata: UncheckedAccount<'info>,
+    
+    /// CHECK: Collection master edition
+    #[account(mut)]
+    pub collection_master_edition: UncheckedAccount<'info>,
+
+    /// CHECK: Recipient of the NFT
+    pub recipient: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+pub struct BurnAndPrepare<'info> {
+    /// CHECK: NFT origin PDA
+    pub nft_origin: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub mint: Account<'info, Mint>,
+
+    #[account(
+        mut,
+        associated_token::mint = mint,
+        associated_token::authority = owner,
+    )]
+    pub token_account: Account<'info, TokenAccount>,
+
+    pub owner: Signer<'info>,
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+#[instruction(sender: [u8; 20], amount: u64, data: Vec<u8>)]
+pub struct OnCall<'info> {
+    #[account(mut)]
+    pub config: Account<'info, state::Config>,
+
+    #[account(
+        seeds = [b"mint_auth"],
+        bump = config.bumps.mint_auth,
+    )]
+    pub mint_auth: SystemAccount<'info>,
+
+    /// CHECK: NFT origin PDA, will be initialized or updated in handler
+    #[account(mut)]
+    pub nft_origin: UncheckedAccount<'info>,
+
+    /// CHECK: Processed message PDA, will be initialized in handler
+    #[account(mut)]
+    pub processed_message: UncheckedAccount<'info>,
+
+    #[account(
+        init,
+        payer = payer,
+        mint::decimals = 0,
+        mint::authority = mint_auth,
+    )]
+    pub mint: Account<'info, Mint>,
+
+    /// CHECK: Token account, will be initialized if needed
+    #[account(mut)]
+    pub token_account: UncheckedAccount<'info>,
+    
+    /// CHECK: Metadata account for NFT
+    #[account(mut)]
+    pub metadata: UncheckedAccount<'info>,
+    
+    /// CHECK: Master edition account for NFT
+    #[account(mut)]
+    pub master_edition: UncheckedAccount<'info>,
+    
+    /// CHECK: Collection mint from config
+    #[account(
+        constraint = collection_mint.key() == config.collection_mint
+    )]
+    pub collection_mint: Account<'info, Mint>,
+    
+    /// CHECK: Collection metadata
+    #[account(mut)]
+    pub collection_metadata: UncheckedAccount<'info>,
+    
+    /// CHECK: Collection master edition
+    #[account(mut)]
+    pub collection_master_edition: UncheckedAccount<'info>,
+
+    /// CHECK: Recipient account, used for ATA creation
+    pub recipient: UncheckedAccount<'info>,
+
+    /// CHECK: Gateway meta account verified in instruction
+    #[account(owner = GATEWAY_PROGRAM_ID)]
+    pub gateway_meta: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub rent: Sysvar<'info, Rent>,
+    pub instructions: Sysvar<'info, Instructions>,
+}
+
+#[derive(Accounts)]
+#[instruction(sender: [u8; 20], data: Vec<u8>)]
+pub struct OnRevert<'info> {
+    #[account(mut)]
+    pub config: Account<'info, state::Config>,
+
+    /// CHECK: Gateway meta account verified in instruction
+    #[account(owner = GATEWAY_PROGRAM_ID)]
+    pub gateway_meta: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+    pub instructions: Sysvar<'info, Instructions>,
+}

--- a/contracts/nft/scripts/solana/payload.ts
+++ b/contracts/nft/scripts/solana/payload.ts
@@ -1,0 +1,192 @@
+/**
+ * Payload encoder for Solana Universal NFT Program
+ * 
+ * This module provides utilities for encoding cross-chain NFT transfer payloads
+ * in a Borsh-compatible format for use with the ZetaChain Gateway.
+ */
+import { PublicKey } from '@solana/web3.js';
+
+/**
+ * Payload interface for cross-chain NFT transfers
+ */
+export interface Payload {
+  /** Unique identifier for the NFT (32 bytes) */
+  token_id: Uint8Array;
+  /** NFT name */
+  name: string;
+  /** NFT symbol */
+  symbol: string;
+  /** Metadata URI */
+  uri: string;
+  /** Recipient Solana address (base58 encoded) */
+  recipient: string;
+  /** Origin chain identifier */
+  origin_chain_id: number;
+  /** Unique nonce to prevent replay attacks */
+  nonce: bigint;
+  /** Original Solana mint address if previously minted on Solana */
+  original_solana_mint?: string | null;
+}
+
+/**
+ * Validates and converts a base58 encoded public key string to a Buffer
+ * @param pubkeyStr Base58 encoded Solana public key
+ * @returns Buffer containing the 32-byte public key
+ * @throws Error if the pubkey is invalid
+ */
+export function parsePubkey(pubkeyStr: string): Buffer {
+  try {
+    const pubkey = new PublicKey(pubkeyStr);
+    return Buffer.from(pubkey.toBytes());
+  } catch (error) {
+    throw new Error(`Invalid public key: ${pubkeyStr}`);
+  }
+}
+
+/**
+ * Encodes a string in Borsh format (u32 length + UTF-8 bytes)
+ * @param str String to encode
+ * @returns Buffer containing the encoded string
+ */
+function encodeString(str: string): Buffer {
+  const strBuffer = Buffer.from(str, 'utf8');
+  const lenBuffer = Buffer.alloc(4);
+  lenBuffer.writeUInt32LE(strBuffer.length, 0);
+  return Buffer.concat([lenBuffer, strBuffer]);
+}
+
+/**
+ * Encodes a u32 value in little-endian format
+ * @param value Number to encode
+ * @returns Buffer containing the encoded u32
+ */
+function encodeU32(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value, 0);
+  return buffer;
+}
+
+/**
+ * Encodes a u64 value in little-endian format
+ * @param value BigInt to encode
+ * @returns Buffer containing the encoded u64
+ */
+function encodeU64(value: bigint): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64LE(value, 0);
+  return buffer;
+}
+
+/**
+ * Encodes an optional public key (Option<Pubkey>)
+ * @param pubkeyStr Optional base58 encoded public key or null
+ * @returns Buffer containing the encoded option
+ */
+function encodeOptionPubkey(pubkeyStr: string | null | undefined): Buffer {
+  if (!pubkeyStr) {
+    // None variant (0)
+    return Buffer.from([0]);
+  }
+  
+  // Some variant (1) + pubkey bytes
+  const pubkeyBuffer = parsePubkey(pubkeyStr);
+  return Buffer.concat([Buffer.from([1]), pubkeyBuffer]);
+}
+
+/**
+ * Validates a payload object
+ * @param payload Payload to validate
+ * @throws Error if validation fails
+ */
+function validatePayload(payload: Payload): void {
+  if (!payload.token_id || payload.token_id.length !== 32) {
+    throw new Error('token_id must be a 32-byte array');
+  }
+  
+  if (!payload.name) {
+    throw new Error('name is required');
+  }
+  
+  if (!payload.symbol) {
+    throw new Error('symbol is required');
+  }
+  
+  if (!payload.uri) {
+    throw new Error('uri is required');
+  }
+  
+  if (!payload.recipient) {
+    throw new Error('recipient is required');
+  }
+  
+  // Validate recipient is a valid Solana address
+  try {
+    new PublicKey(payload.recipient);
+  } catch (error) {
+    throw new Error(`Invalid recipient address: ${payload.recipient}`);
+  }
+  
+  if (typeof payload.origin_chain_id !== 'number') {
+    throw new Error('origin_chain_id must be a number');
+  }
+  
+  if (typeof payload.nonce !== 'bigint') {
+    throw new Error('nonce must be a bigint');
+  }
+  
+  // Validate optional original_solana_mint if provided
+  if (payload.original_solana_mint) {
+    try {
+      new PublicKey(payload.original_solana_mint);
+    } catch (error) {
+      throw new Error(`Invalid original_solana_mint address: ${payload.original_solana_mint}`);
+    }
+  }
+}
+
+/**
+ * Encodes a payload into a Borsh-compatible Buffer
+ * @param payload Payload to encode
+ * @returns Buffer containing the encoded payload
+ */
+export function encodePayload(payload: Payload): Buffer {
+  // Validate the payload
+  validatePayload(payload);
+  
+  // Encode each field
+  const encodedBuffers = [
+    Buffer.from(payload.token_id),               // token_id: [u8; 32]
+    encodeString(payload.name),                  // name: String
+    encodeString(payload.symbol),                // symbol: String
+    encodeString(payload.uri),                   // uri: String
+    parsePubkey(payload.recipient),              // recipient: Pubkey
+    encodeU32(payload.origin_chain_id),          // origin_chain_id: u32
+    encodeU64(payload.nonce),                    // nonce: u64
+    encodeOptionPubkey(payload.original_solana_mint), // original_solana_mint: Option<Pubkey>
+  ];
+  
+  // Concatenate all encoded fields
+  return Buffer.concat(encodedBuffers);
+}
+
+/**
+ * Creates a payload with default values for testing
+ * @param overrides Fields to override in the default payload
+ * @returns A payload object with default values
+ */
+export function createTestPayload(overrides: Partial<Payload> = {}): Payload {
+  // Create a default token_id if not provided
+  const token_id = overrides.token_id || new Uint8Array(32).fill(1);
+  
+  return {
+    token_id,
+    name: "Test NFT",
+    symbol: "TEST",
+    uri: "https://example.com/metadata.json",
+    recipient: "11111111111111111111111111111111",  // Default to system program
+    origin_chain_id: 1,
+    nonce: BigInt(Date.now()),
+    original_solana_mint: null,
+    ...overrides
+  };
+}

--- a/contracts/nft/scripts/solana/sendToZeta.ts
+++ b/contracts/nft/scripts/solana/sendToZeta.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env ts-node
+/**
+ * Send to ZetaChain - Payload Encoder
+ * 
+ * This script encodes NFT transfer payload data for use with the ZetaChain Gateway.
+ * It does not perform any network calls, just encodes and prints the payload.
+ * 
+ * Usage:
+ *   ts-node sendToZeta.ts <token_id_hex_32> <name> <symbol> <uri> <recipient_base58> <origin_chain_id> [<original_solana_mint>] [<nonce>]
+ * 
+ * Example:
+ *   ts-node sendToZeta.ts 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f "My NFT" "MNFT" "https://example.com/1.json" EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v 7000
+ */
+
+import { encodePayload } from './payload';
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+
+if (args.length < 6) {
+  console.error(`
+Usage: ts-node sendToZeta.ts <token_id_hex_32> <name> <symbol> <uri> <recipient_base58> <origin_chain_id> [<original_solana_mint>] [<nonce>]
+
+Arguments:
+  token_id_hex_32     - 64 hex characters (32 bytes)
+  name                - NFT name
+  symbol              - NFT symbol
+  uri                 - Metadata URI
+  recipient_base58    - Solana recipient address (base58)
+  origin_chain_id     - Origin chain identifier (number)
+  original_solana_mint - [Optional] Original Solana mint if previously on Solana
+  nonce               - [Optional] Unique nonce (defaults to current timestamp)
+  `);
+  process.exit(1);
+}
+
+// Parse token_id (convert from hex string to Uint8Array)
+const tokenIdHex = args[0];
+if (tokenIdHex.length !== 64 || !/^[0-9a-fA-F]+$/.test(tokenIdHex)) {
+  console.error('Error: token_id must be exactly 64 hex characters (32 bytes)');
+  process.exit(1);
+}
+
+const tokenIdBytes = new Uint8Array(32);
+for (let i = 0; i < 32; i++) {
+  tokenIdBytes[i] = parseInt(tokenIdHex.substring(i * 2, i * 2 + 2), 16);
+}
+
+// Parse other arguments
+const name = args[1];
+const symbol = args[2];
+const uri = args[3];
+const recipient = args[4];
+const originChainId = parseInt(args[5], 10);
+const originalSolanaMint = args.length > 6 ? args[6] : null;
+const nonce = args.length > 7 ? BigInt(args[7]) : BigInt(Date.now());
+
+// Create the payload
+const payload = {
+  token_id: tokenIdBytes,
+  name,
+  symbol,
+  uri,
+  recipient,
+  origin_chain_id: originChainId,
+  nonce,
+  original_solana_mint: originalSolanaMint
+};
+
+try {
+  // Encode the payload
+  const encodedPayload = encodePayload(payload);
+  
+  // Convert to different formats
+  const base64Payload = encodedPayload.toString('base64');
+  const hexPayload = encodedPayload.toString('hex');
+  
+  // Create a JSON blob for gateway call
+  const gatewayCallJson = {
+    zrc20: "0x0000000000000000000000000000000000000000", // ZRC20_NULL for message-only calls
+    amount: "0",
+    message: base64Payload,
+    to: "Un1v3rsa1Nft111111111111111111111111111111", // Universal NFT program ID
+    // Note: In a real implementation, you would include gas parameters
+  };
+  
+  // Print the results
+  console.log('\n=== ENCODED PAYLOAD ===');
+  console.log('\nBase64:');
+  console.log(base64Payload);
+  
+  console.log('\nHex:');
+  console.log(hexPayload);
+  
+  console.log('\n=== GATEWAY CALL JSON ===');
+  console.log(JSON.stringify(gatewayCallJson, null, 2));
+  
+  console.log('\n=== PAYLOAD DETAILS ===');
+  console.log(JSON.stringify({
+    token_id: tokenIdHex,
+    name,
+    symbol,
+    uri,
+    recipient,
+    origin_chain_id: originChainId,
+    nonce: nonce.toString(),
+    original_solana_mint: originalSolanaMint
+  }, null, 2));
+  
+  console.log('\nTo use with ZetaChain Gateway:');
+  console.log('1. Fund your account with SOL for deposit fee (0.002 SOL)');
+  console.log('2. Call Gateway.depositAndCall with the above payload');
+  console.log('3. Include a compute budget instruction if needed (200k+ CU recommended)');
+  
+} catch (error) {
+  console.error('Error encoding payload:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
This PR adds a complete Solana Universal NFT program for ZetaChain interoperability (issue #72).\n\nHighlights:\n- Anchor program implementing initialize, mint_local, burn_and_prepare, on_call, on_revert\n- PDAs: Config, MintAuthority, Treasury, NftOrigin, ProcessedMessage (replay protection)\n- Gateway verification via sysvar instructions + meta PDA validation\n- Metaplex Token Metadata CPIs: collection mint, metadata, master edition, collection verification\n- Borsh payload: token_id [u8;32], name, symbol, uri, recipient Pubkey, origin_chain_id u32, nonce u64, original_solana_mint Option<Pubkey>\n- TypeScript payload encoder + CLI stub to produce base64/hex payloads\n\nPath:\n- contracts/nft/contracts/solana/universal_nft (Anchor program + README)\n- contracts/nft/scripts/solana (payload encoder + sendToZeta.ts)\n\nSecurity:\n- Strict Gateway caller verification via sysvar::instructions check and known program id\n- PDA-based auth, treasury, and replay protection\n\nNotes:\n- Default cluster: testnet (can switch via Anchor config)\n- Scripts generate payload for Gateway withdrawAndCall to target Solana program on-call\n- Build/test not executed on this machine (Anchor not installed) — code follows Anchor and Metaplex patterns and compiles in standard setups.\n\nTesting outline:\n1) anchor deploy (testnet)\n2) anchor run initialize\n3) anchor run mint_local\n4) anchor run burn_and_prepare (emits token_id)\n5) ts-node scripts/solana/sendToZeta.ts <args> → message base64\n6) Call GatewayZEVM.withdrawAndCall with ZRC20_NULL, amount=0, to=<program id bytes>, message=<base64>\n7) Observe Solana tx mints NFT to recipient in on_call\n\nDroid-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Solana Universal NFT program with initialize, local mint, burn-and-prepare, inbound receive, and revert flows.
  - Emitted events for outbound preparation and inbound receipt.
  - Added scripts to encode NFT payloads and generate Gateway call JSON for cross-chain transfers.

- Documentation
  - Added comprehensive README with setup, deployment, usage examples, security notes, and environment configuration.

- Chores
  - Added project configuration for Solana/Anchor, including program IDs, provider settings, and build/deploy scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->