### PR TITLE
fix: Unauthorized NFT burn in cross-chain transfer path (missing ownership/approval check)

### DIFF
--- a/contracts/nft/contracts/evm/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/evm/UniversalNFTCore.sol
@@ -163,6 +163,11 @@ abstract contract UniversalNFTCore is
             revert TransferToZetaChainRequiresNoGas();
         }
 
+        address owner = _requireOwned(tokenId);
+        if (!_isAuthorized(owner, _msgSender(), tokenId)) {
+            revert Unauthorized();
+        }
+
         string memory uri = tokenURI(tokenId);
         bytes memory payload = abi.encode(
             destination,

--- a/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
+++ b/contracts/nft/contracts/zetachain/UniversalNFTCore.sol
@@ -176,6 +176,11 @@ abstract contract UniversalNFTCore is
         if (msg.value == 0) revert ZeroMsgValue();
         if (receiver == address(0)) revert InvalidAddress();
 
+        address owner = _requireOwned(tokenId);
+        if (!_isAuthorized(owner, _msgSender(), tokenId)) {
+            revert Unauthorized();
+        }
+
         string memory uri = tokenURI(tokenId);
         bytes memory payload = abi.encode(
             receiver,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-chain NFT transfers now enforce standard ownership/approval checks before execution on all supported chains. Only token owners or approved operators can initiate a cross-chain transfer; unauthorized attempts are blocked with a clear error. Existing transfer flows, fees handling, and payload construction remain unchanged. No public APIs were modified. This improves security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->